### PR TITLE
Export type definitions from Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Export types for Jest so that TypeScript compiler can find them.
+
 ## [0.1.4] - 2019-03-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2019-03-22
+
 ### Fixed
 
 - Export types for Jest so that TypeScript compiler can find them.

--- a/examples/typescript/README.md
+++ b/examples/typescript/README.md
@@ -10,4 +10,6 @@ yarn add typescript @types/graphql @types/jest @types/node @types/react @types/r
 
 Add a `tsconfig.json` file just like [`tsconfig.json`](./tsconfig.json).
 
+Notice that you need to import `@vtex/test-tools/react` whenever you want to use Jest, since `react.d.ts` exports the types for Jest.
+
 Done 🎉

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/test-tools",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "VTEX IO testing tools",
   "bin": {
     "vtex-test-tools": "./bin/vtex-test-tools.js"

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,2 +1,5 @@
 export * from 'react-testing-library';
+// Exporting type definitions for Jest so that TypeScript Compiler can find it.
+// This is necessary for testing projects that use TypeScript.
+// Trying to find a better solution, check (https://github.com/vtex/test-tools/issues/7)
 export * from '@types/jest';

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,1 +1,2 @@
-export * from "react-testing-library";
+export * from 'react-testing-library';
+export * from '@types/jest';


### PR DESCRIPTION
This adds a `export * from '@types/jest'` to `react.d.ts` file so that linters and TypeScript compiler are able to find the type definitions from Jest and don't throw type errors.

Notice that this is depends on the user to `import '@vtex/test-tools/react'` in his tests.
If anyone has a solution that would export those types in a way in which the user would be able to use functions from Jest without importing `@vtex/test-tools/react`, please share it :)