### PR TITLE
Use jest.config.js if it exists on project root

### DIFF
--- a/scripts/test.js
+++ b/scripts/test.js
@@ -10,18 +10,23 @@ process.on('unhandledRejection', err => {
 
 const jest = require('jest')
 const path = require('path')
+const fs = require('fs')
 const paths = require('../modules/paths')
 const createJestConfig = require('../modules/createJestConfig')
 
 function startTest(...processArgs) {
   const args = processArgs ? processArgs.slice(0) : []
 
-  const config = createJestConfig(
-    relativePath => path.resolve(__dirname, '..', relativePath),
-    paths.resolveAppPath
-  )
+  const shouldGenerateConfig = !fs.existsSync(path.join(process.cwd(), 'jest.config.js'))
 
-  args.push('--config', JSON.stringify(config))
+  if (shouldGenerateConfig) {
+    const config = createJestConfig(
+      relativePath => path.resolve(__dirname, '..', relativePath),
+      paths.resolveAppPath
+    )
+      
+    args.push('--config', JSON.stringify(config))
+  }  
 
   jest.run(args)
 }


### PR DESCRIPTION
This PR will allow to use `@vtex/test-tools` with custom jest configs.

To test link this project and link it on another project which uses @vtex/test-tools, create a `jest.config.js` on project root, like this one for example:
```
module.exports = {
  roots: ['<rootDir>'],
  transform: {
    '^.+\\.tsx?$': 'ts-jest',
  },
  testRegex: '(/__tests__/.*(test|spec)).tsx?$WOLOLO',
  testEnvironment: 'node',
}
```
Run `vtex-test-tools test --debug`. The `testRegex` showed should be equal to the one above.
