### PR TITLE
Upgrade to react-apollo@3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2019-12-03
+
 ### Changed
 
 - Upgraded `react-apollo` to major 3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgraded `react-apollo` to major 3.
+
 ## [1.2.1] - 2019-11-07
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ test('should render the example translated to portuguese', () => {
 
 #### GraphQL
 
-We automatically wrap your component with an Apollo's [`MockProvider`](https://www.apollographql.com/docs/react/recipes/testing.html).
+We automatically wrap your component with an Apollo's [`MockedProvider`](https://www.apollographql.com/docs/react/development-testing/testing/). Just import it from `@apollo/react-testing` and pass it as the `MockedProvider` option.
 
 You can pass props to it using the `graphql` option. Example:
 
 ```js
 import React from 'react'
 import { render, flushPromises } from '@vtex/test-tools/react'
+import { MockedProvider } from '@apollo/react-testing'
 import GraphqlComponent from './GraphqlComponent'
 import GET_BOOKS from './getBooks.graphql'
 
@@ -131,7 +132,8 @@ test('should render mock graphql responses', async () => {
   }
 
   const { getByText } = render(<GraphqlComponent />, {
-    graphql: { mocks: [bookMock] }
+    graphql: { mocks: [bookMock] },
+    MockedProvider,
   })
 
   expect(getByText(/Loading/)).toBeDefined()

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "vtex-test-tools": "./bin/vtex-test-tools.js"
   },
   "dependencies": {
+    "@apollo/react-testing": "^3.1.3",
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
     "@babel/plugin-transform-runtime": "^7.3.4",
@@ -21,7 +22,7 @@
     "@types/react": "^16.8.7",
     "@types/react-intl": "^2.3.17",
     "apollo-cache-inmemory": "^1.6.3",
-    "apollo-client": "^2.5.1",
+    "apollo-client": "^2.6.4",
     "babel-jest": "^24.4.0",
     "babel-plugin-dynamic-import-node": "^2.2.0",
     "fs-extra": "~5.0.0",
@@ -32,7 +33,7 @@
     "jest-transform-graphql": "^2.1.0",
     "ramda": "^0.26.1",
     "react": "^16.9.0",
-    "react-apollo": "^2.5.2",
+    "react-apollo": "^3.1.3",
     "react-dom": "^16.9.0",
     "react-intl": "^2.8.0",
     "regenerator-runtime": "^0.13.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/test-tools",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "VTEX IO testing tools",
   "bin": {
     "vtex-test-tools": "./bin/vtex-test-tools.js"

--- a/react.d.ts
+++ b/react.d.ts
@@ -1,5 +1,5 @@
 import { RenderOptions, RenderResult } from "@testing-library/react";
-import { MockedProviderProps } from "react-apollo/test-utils";
+import { MockedProviderProps } from "@apollo/react-testing";
 
 export * from "@testing-library/react";
 
@@ -10,13 +10,20 @@ interface Messages {
   [id: string]: string;
 }
 
-interface TestToolsRenderOptions extends RenderOptions {
-  /** Props to be passed to MockedProvider from react-apollo. */
-  graphql?: MockedProviderProps;
+type TestToolsRenderOptions = BaseTestToolsRenderOptions | GraphQLTestToolsRenderOptions
+
+interface BaseTestToolsRenderOptions extends RenderOptions {
   /** A locale string, eg: `pt-BR`, `es`. Default: `en`*/
   locale?: string;
   /** A JSON translation to be used. Default: `messages/en.json` or another locale if specified in the `locale` option. */
   messages?: Messages;
+}
+
+interface GraphQLTestToolsRenderOptions extends BaseTestToolsRenderOptions {
+  /** Props to be passed to MockedProvider */
+  graphql: MockedProviderProps;
+  /** The MockedProvider from @apollo/react-testing */
+  MockedProvider: React.ComponentType;
 }
 
 /**

--- a/react.js
+++ b/react.js
@@ -1,7 +1,7 @@
 const React = require('react')
 const reactTestingLibrary = require('@testing-library/react')
+const { MockedProvider } = require('@apollo/react-testing')
 const { IntlProvider } = require('react-intl')
-const { MockedProvider } = require('react-apollo/test-utils')
 const { path, insertAll, reject, isNil, find } = require('ramda')
 const { InMemoryCache } = require('apollo-cache-inmemory')
 
@@ -43,6 +43,8 @@ const customRender = (node, options = {}) => {
     messages: messages,
   }
 
+  const Provider = options.MockedProvider || MockedProvider
+
   const apolloProps = options.graphql
     ? Object.assign({}, { addTypename: false }, options.graphql)
     : { mocks: [], addTypename: false }
@@ -58,7 +60,7 @@ const customRender = (node, options = {}) => {
     React.createElement(
       IntlProvider,
       intlProps,
-      React.createElement(MockedProvider, apolloProps, node)
+      React.createElement(Provider, apolloProps, node)
     ),
     options
   )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,64 @@
 # yarn lockfile v1
 
 
+"@apollo/react-common@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-common/-/react-common-3.1.3.tgz#ddc34f6403f55d47c0da147fd4756dfd7c73dac5"
+  integrity sha512-Q7ZjDOeqjJf/AOGxUMdGxKF+JVClRXrYBGVq+SuVFqANRpd68MxtVV2OjCWavsFAN0eqYnRqRUrl7vtUCiJqeg==
+  dependencies:
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-components@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-3.1.3.tgz#8f6726847cd9b0eb4b22586b1a038d29aa8b1da4"
+  integrity sha512-H0l2JKDQMz+LkM93QK7j3ThbNXkWQCduN3s3eKxFN3Rdg7rXsrikJWvx2wQ868jmqy0VhwJbS1vYdRLdh114uQ==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    prop-types "^15.7.2"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hoc@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hoc/-/react-hoc-3.1.3.tgz#5742ee74f57611058f5ea1f966c38fc6429dda7b"
+  integrity sha512-oCPma0uBVPTcYTR5sOvtMbpaWll4xDBvYfKr6YkDorUcQVeNzFu1LK1kmQjJP64bKsaziKYji5ibFaeCnVptmA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-components" "^3.1.3"
+    hoist-non-react-statics "^3.3.0"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-hooks@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-hooks/-/react-hooks-3.1.3.tgz#ad42c7af78e81fee0f30e53242640410d5bd0293"
+  integrity sha512-reIRO9xKdfi+B4gT/o/hnXuopUnm7WED/ru8VQydPw+C/KG/05Ssg1ZdxFKHa3oxwiTUIDnevtccIH35POanbA==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@wry/equality" "^0.1.9"
+    ts-invariant "^0.4.4"
+    tslib "^1.10.0"
+
+"@apollo/react-ssr@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-ssr/-/react-ssr-3.1.3.tgz#0791280d5b735f42f87dbfe849564e78843045bc"
+  integrity sha512-fUTmEYHxSTX1GA43B8vICxXXplpcEBnDwn0IgdAc3eG0p2YK97ZrJDRFCJ5vD7fyDZsrYhMf+rAI3sd+H2SS+A==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    tslib "^1.10.0"
+
+"@apollo/react-testing@^3.1.3":
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@apollo/react-testing/-/react-testing-3.1.3.tgz#d8dd318f58fb6a404976bfa3f8a79e976a5c6562"
+  integrity sha512-58R7gROl4TZMHm5kS76Nof9FfZhD703AU3SmJTA2f7naiMqC9Qd8pZ4oNCBafcab0SYN//UtWvLcluK5O7V/9g==
+  dependencies:
+    "@apollo/react-common" "^3.1.3"
+    fast-json-stable-stringify "^2.0.0"
+    tslib "^1.10.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -1111,7 +1169,7 @@
     "@types/node" ">=6"
     tslib "^1.9.3"
 
-"@wry/equality@^0.1.2":
+"@wry/equality@^0.1.2", "@wry/equality@^0.1.9":
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.1.9.tgz#b13e18b7a8053c6858aa6c85b54911fb31e3a909"
   integrity sha512-mB6ceGjpMGz1ZTza8HYnrPGos2mC6So4NhS1PtZ8s4Qt0K7fBiIGhpSxUbQmhwcSWE3no+bYxmI2OL6KuXYmoQ==
@@ -1215,7 +1273,7 @@ apollo-cache@1.3.2, apollo-cache@^1.3.2:
     apollo-utilities "^1.3.2"
     tslib "^1.9.3"
 
-apollo-client@^2.5.1:
+apollo-client@^2.6.4:
   version "2.6.4"
   resolved "https://registry.yarnpkg.com/apollo-client/-/apollo-client-2.6.4.tgz#872c32927263a0d34655c5ef8a8949fbb20b6140"
   integrity sha512-oWOwEOxQ9neHHVZrQhHDbI6bIibp9SHgxaLRVPoGvOFy7OH5XUykZE7hBQAVxq99tQjBzgytaZffQkeWo1B4VQ==
@@ -3112,11 +3170,6 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.isequal@^4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
-  integrity sha1-QVxEePK8wwEgwizhDtMib30+GOA=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3732,18 +3785,16 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo@^2.5.2:
-  version "2.5.8"
-  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.5.8.tgz#c7a593b027efeefdd8399885e0ac6bec3b32623c"
-  integrity sha512-60yOQrnNosxU/tRbOxGDaYNLFcOKmQqxHPhxyvKTlGIaF/rRCXQRKixUgWVffpEupSHHD7psY5k5ZOuZsdsSGQ==
+react-apollo@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-3.1.3.tgz#5d8540b401bba36173b63e6c5e75fa561960c63e"
+  integrity sha512-orCZNoAkgveaK5b75y7fw1MSqSHOU/Wuu9rRFOGmRQBSQVZjvV4DI+hj604rHmuN9+WDABxb5W48wTa0F/xNZQ==
   dependencies:
-    apollo-utilities "^1.3.0"
-    fast-json-stable-stringify "^2.0.0"
-    hoist-non-react-statics "^3.3.0"
-    lodash.isequal "^4.5.0"
-    prop-types "^15.7.2"
-    ts-invariant "^0.4.2"
-    tslib "^1.9.3"
+    "@apollo/react-common" "^3.1.3"
+    "@apollo/react-components" "^3.1.3"
+    "@apollo/react-hoc" "^3.1.3"
+    "@apollo/react-hooks" "^3.1.3"
+    "@apollo/react-ssr" "^3.1.3"
 
 react-dom@^16.9.0:
   version "16.9.0"
@@ -4435,14 +4486,14 @@ trim-right@^1.0.1:
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
   integrity sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=
 
-ts-invariant@^0.4.0, ts-invariant@^0.4.2:
+ts-invariant@^0.4.0, ts-invariant@^0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.4.4.tgz#97a523518688f93aafad01b0e80eb803eb2abd86"
   integrity sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==
   dependencies:
     tslib "^1.9.3"
 
-tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.3:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
   integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==


### PR DESCRIPTION
This makes our `test-tools` support `react-apollo@3.x`. Since this is a breaking change (because `react-apollo@3.x` is not fully backwards compatible), this PR requires a major bump.

One issue we found when upgrading `react-apollo` is that we couldn't make `MockedProvider` work when imported in `test-tools`. The workaround is to require the user to import `MockedProvider` from `@apollo/react-testing` and pass it as argument to the `render` function. Suggestions on how to improve this case are welcome.