### PR TITLE
Get the coverageThreshold configuration from package.json file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Get the `coverageThreshold` configuration from `package.json` file.
+
 ## [3.0.3] - 2020-02-13
 ### Changed
 - Upgrade `@babel/preset-env` and `@babel/core` packages to `v7.8.0`.

--- a/modules/createJestConfig.js
+++ b/modules/createJestConfig.js
@@ -11,21 +11,24 @@ module.exports = (resolve, resolveAppPath) => {
   if (pkg.jest && pkg.jest.setupFilesAfterEnv) {
     setupFilesAfterEnv = setupFilesAfterEnv.concat(pkg.jest.setupFilesAfterEnv)
   }
+  const coverageThreshold =
+    pkg.jest && pkg.jest.coverageThreshold ? pkg.jest.coverageThreshold : {}
 
   let config = {
     rootDir: resolveAppPath('.'),
     setupFilesAfterEnv: setupFilesAfterEnv,
+    coverageThreshold: coverageThreshold,
     moduleNameMapper: {
-      "^.+\\.css$": require.resolve('identity-obj-proxy'),
-      "^react$": require.resolve('react'),
+      '^.+\\.css$': require.resolve('identity-obj-proxy'),
+      '^react$': require.resolve('react'),
     },
     transform: {
-      "\\.(gql|graphql)$": require.resolve('jest-transform-graphql'),
-      "^.+\\.(js|jsx|mjs|ts|tsx)$": resolve('modules/jest/babelTransform.js'),
+      '\\.(gql|graphql)$': require.resolve('jest-transform-graphql'),
+      '^.+\\.(js|jsx|mjs|ts|tsx)$': resolve('modules/jest/babelTransform.js'),
       '^(?!.*\\.(js|jsx|mjs|css|ts|tsx|json|graphql|gql)$)': resolve(
         'modules/jest/fileTransform.js'
       ),
-    }
+    },
   }
 
   return config


### PR DESCRIPTION
Read the pkg configuration and get coverageThreshold for pass to the jest configuration. This will be used to configure minimum threshold enforcement for coverage results