### PR TITLE
Re-adding missing `graphql-tag` dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [3.3.1] - 2020-08-10
 ### Fixed
 - Adding missing dependency `graphql-tag`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adding missing dependency `graphql-tag`.
 
 ## [3.3.0] - 2020-08-10
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vtex/test-tools",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "VTEX IO testing tools",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-jest": "^24.4.0",
     "babel-plugin-const-enum": "^1.0.1",
     "graphql": "^14.0.0",
+    "graphql-tag": "^2.11.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.0.0",
     "jest-transform-graphql": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3305,6 +3305,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.4
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql-tag@^2.11.0:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.11.0.tgz#1deb53a01c46a7eb401d6cb59dec86fa1cccbffd"
+  integrity sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==
+
 graphql@*:
   version "15.3.0"
   resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.3.0.tgz#3ad2b0caab0d110e3be4a5a9b2aa281e362b5278"


### PR DESCRIPTION
Previous https://github.com/vtex/test-tools/pull/37 PR, removed `graphql-tag` dependecy. This dependency is a `peerDependency` of `jest-transform-graphql`.